### PR TITLE
Implement core image-to-ASCII conversion

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ascii-converter",
+  "version": "1.0.0",
+  "description": "Convert images to ASCII art",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "sharp": "^0.33.2"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,46 @@
+import sharp from "sharp";
+
+const DEFAULT_CHARSET = " .:-=+*#%@";
+const DEFAULT_WIDTH = 80;
+const DEFAULT_HEIGHT = 40;
+
+export interface ConvertOptions {
+  width?: number;
+  height?: number;
+  charset?: string;
+  invert?: boolean;
+}
+
+export async function convert(
+  inputPath: string,
+  options: ConvertOptions = {}
+): Promise<string> {
+  const {
+    width = DEFAULT_WIDTH,
+    height = DEFAULT_HEIGHT,
+    charset = DEFAULT_CHARSET,
+    invert = true,
+  } = options;
+
+  const { data } = await sharp(inputPath)
+    .resize(width, height, { fit: "fill" })
+    .grayscale()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  const lines: string[] = [];
+
+  for (let y = 0; y < height; y++) {
+    let line = "";
+    for (let x = 0; x < width; x++) {
+      const brightness = data[y * width + x];
+      const idx = invert
+        ? Math.floor(((255 - brightness) / 255) * (charset.length - 1))
+        : Math.floor((brightness / 255) * (charset.length - 1));
+      line += charset[idx];
+    }
+    lines.push(line);
+  }
+
+  return lines.join("\n");
+}

--- a/tests/convert.test.ts
+++ b/tests/convert.test.ts
@@ -1,0 +1,73 @@
+import { convert } from "../src/index";
+import { createTestImage, solidImage } from "./helpers";
+import fs from "fs";
+import path from "path";
+
+const FIXTURES_DIR = path.join(__dirname, "fixtures");
+
+afterAll(() => {
+  if (fs.existsSync(FIXTURES_DIR)) {
+    fs.rmSync(FIXTURES_DIR, { recursive: true });
+  }
+});
+
+describe("convert", () => {
+  test("returns correct dimensions with default options", async () => {
+    const imgPath = await createTestImage("dim.png", 100, 100, 3, solidImage(100, 100, 128, 128, 128));
+    const result = await convert(imgPath);
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(40);
+    lines.forEach((line) => expect(line).toHaveLength(80));
+  });
+
+  test("respects custom width and height", async () => {
+    const imgPath = await createTestImage("custom.png", 50, 50, 3, solidImage(50, 50, 100, 100, 100));
+    const result = await convert(imgPath, { width: 40, height: 20 });
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(20);
+    lines.forEach((line) => expect(line).toHaveLength(40));
+  });
+
+  test("white image with invert=true maps to darkest characters", async () => {
+    const imgPath = await createTestImage("white.png", 10, 10, 3, solidImage(10, 10, 255, 255, 255));
+    const charset = " .:-=+*#%@";
+    const result = await convert(imgPath, { width: 10, height: 10, charset, invert: true });
+    // White pixels (255) with invert → index 0 → space (darkest in ramp)
+    const lines = result.split("\n");
+    lines.forEach((line) => expect(line).toBe(" ".repeat(10)));
+  });
+
+  test("black image with invert=true maps to brightest characters", async () => {
+    const imgPath = await createTestImage("black.png", 10, 10, 3, solidImage(10, 10, 0, 0, 0));
+    const charset = " .:-=+*#%@";
+    const result = await convert(imgPath, { width: 10, height: 10, charset, invert: true });
+    // Black pixels (0) with invert → index 9 → '@'
+    const lines = result.split("\n");
+    lines.forEach((line) => expect(line).toBe("@".repeat(10)));
+  });
+
+  test("invert=false reverses the mapping", async () => {
+    const imgPath = await createTestImage("white_noinv.png", 10, 10, 3, solidImage(10, 10, 255, 255, 255));
+    const charset = " .:-=+*#%@";
+    const result = await convert(imgPath, { width: 10, height: 10, charset, invert: false });
+    // White pixels (255) without invert → index 9 → '@'
+    const lines = result.split("\n");
+    lines.forEach((line) => expect(line).toBe("@".repeat(10)));
+  });
+
+  test("works with JPG input", async () => {
+    const imgPath = await createTestImage("test.jpg", 50, 50, 3, solidImage(50, 50, 128, 128, 128));
+    const result = await convert(imgPath, { width: 20, height: 10 });
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(10);
+    lines.forEach((line) => expect(line).toHaveLength(20));
+  });
+
+  test("custom charset is used", async () => {
+    const imgPath = await createTestImage("custom_charset.png", 10, 10, 3, solidImage(10, 10, 0, 0, 0));
+    const result = await convert(imgPath, { width: 5, height: 5, charset: "AB", invert: true });
+    // Black (0) with invert → max index → 'B'
+    const lines = result.split("\n");
+    lines.forEach((line) => expect(line).toBe("BBBBB"));
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,38 @@
+import sharp from "sharp";
+import path from "path";
+import fs from "fs";
+
+const FIXTURES_DIR = path.join(__dirname, "fixtures");
+
+export async function createTestImage(
+  name: string,
+  width: number,
+  height: number,
+  channels: 3 | 4,
+  pixels: Buffer
+): Promise<string> {
+  if (!fs.existsSync(FIXTURES_DIR)) {
+    fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  }
+  const filePath = path.join(FIXTURES_DIR, name);
+  await sharp(pixels, { raw: { width, height, channels } })
+    .toFormat(name.endsWith(".png") ? "png" : "jpeg")
+    .toFile(filePath);
+  return filePath;
+}
+
+export function solidImage(
+  width: number,
+  height: number,
+  r: number,
+  g: number,
+  b: number
+): Buffer {
+  const buf = Buffer.alloc(width * height * 3);
+  for (let i = 0; i < width * height; i++) {
+    buf[i * 3] = r;
+    buf[i * 3 + 1] = g;
+    buf[i * 3 + 2] = b;
+  }
+  return buf;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- Add `convert(inputPath, options)` function that loads PNG/JPG images via `sharp`, resizes to target character dimensions, converts to grayscale, and maps brightness values to an ASCII character ramp
- Supports `width`, `height`, `charset`, and `invert` options with sensible defaults (80x40, standard ramp, invert enabled)
- Exports the function and `ConvertOptions` interface from `src/index.ts`
- Includes 7 unit tests covering dimension constraints, invert toggle, JPG input, and custom charset

Closes #1

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (exact-puffin) 🤖