### PR TITLE
Add CLI interface for image-to-ASCII conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 *.js.map
+.DS_Store
+*.tgz

--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+# ascii-converter
+
+Convert images (PNG/JPG) to ASCII art from the terminal.
+
+## Installation
+
+```bash
+npm install -g ascii-converter
+```
+
+Or run directly with npx:
+
+```bash
+npx ascii-converter image.png
+```
+
+## Usage
+
+```
+ascii-converter <input> [options]
+
+Options:
+  --width, -w      Output width in characters (default: 80)
+  --height, -h     Output height in characters (default: 40)
+  --charset, -c    Character ramp (default: built-in grayscale)
+  --invert, -i     Invert brightness (default: true)
+  --output, -o     Output file path (default: stdout)
+  --batch, -b      Glob pattern for batch conversion
+  --help           Show help
+  --version        Show version
+```
+
+## Examples
+
+Convert an image and print to stdout:
+
+```bash
+ascii-converter photo.png
+```
+
+Specify dimensions:
+
+```bash
+ascii-converter photo.png -w 120 -h 60
+```
+
+Save to a file:
+
+```bash
+ascii-converter photo.png -o output.txt
+```
+
+Batch convert all PNGs in a directory:
+
+```bash
+ascii-converter -b "images/*.png" -w 100 -h 50
+```
+
+## Library Usage
+
+```typescript
+import { convert } from 'ascii-converter';
+
+const ascii = await convert('image.png', {
+  width: 80,
+  height: 40,
+  invert: true,
+});
+console.log(ascii);
+```
+
+## Development
+
+```bash
+npm install
+npm run build
+npm test
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ascii-converter",
+  "version": "1.0.0",
+  "description": "Convert images to ASCII art",
+  "main": "dist/converter.js",
+  "bin": {
+    "ascii-converter": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/cli.js",
+    "test": "jest --verbose"
+  },
+  "keywords": ["ascii", "art", "image", "converter"],
+  "license": "MIT",
+  "dependencies": {
+    "commander": "^12.0.0",
+    "glob": "^10.3.0",
+    "sharp": "^0.33.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { convert, ConvertOptions } from './converter';
+import { glob } from 'glob';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const program = new Command();
+
+program
+  .name('ascii-converter')
+  .description('Convert images to ASCII art')
+  .version('1.0.0')
+  .argument('[input]', 'Input image file path')
+  .option('-w, --width <number>', 'Output width in characters', '80')
+  .option('-h, --height <number>', 'Output height in characters', '40')
+  .option('-c, --charset <string>', 'Character ramp')
+  .option('-i, --invert <boolean>', 'Invert brightness', 'true')
+  .option('-o, --output <path>', 'Output file path (default: stdout)')
+  .option('-b, --batch <pattern>', 'Glob pattern for batch conversion')
+  .action(async (input: string | undefined, opts: Record<string, string>) => {
+    try {
+      const convertOpts: ConvertOptions = {
+        width: parseInt(opts.width, 10),
+        height: parseInt(opts.height, 10),
+        invert: opts.invert !== 'false',
+      };
+
+      if (opts.charset) {
+        convertOpts.charset = opts.charset;
+      }
+
+      if (isNaN(convertOpts.width!) || convertOpts.width! < 1) {
+        console.error('Error: --width must be a positive integer');
+        process.exit(1);
+      }
+      if (isNaN(convertOpts.height!) || convertOpts.height! < 1) {
+        console.error('Error: --height must be a positive integer');
+        process.exit(1);
+      }
+
+      if (opts.batch) {
+        await handleBatch(opts.batch, convertOpts);
+        return;
+      }
+
+      if (!input) {
+        console.error('Error: No input file specified. Use --help for usage.');
+        process.exit(1);
+      }
+
+      if (!fs.existsSync(input)) {
+        console.error(`Error: File not found: ${input}`);
+        process.exit(1);
+      }
+
+      const result = await convert(input, convertOpts);
+
+      if (opts.output) {
+        fs.writeFileSync(opts.output, result, 'utf-8');
+        console.error(`Written to ${opts.output}`);
+      } else {
+        console.log(result);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Error: ${message}`);
+      process.exit(1);
+    }
+  });
+
+async function handleBatch(
+  pattern: string,
+  opts: ConvertOptions
+): Promise<void> {
+  const files = await glob(pattern);
+
+  if (files.length === 0) {
+    console.error(`Error: No files matched pattern: ${pattern}`);
+    process.exit(1);
+  }
+
+  for (const file of files) {
+    try {
+      const result = await convert(file, opts);
+      const outputPath = file.replace(/\.[^.]+$/, '.txt');
+      fs.writeFileSync(outputPath, result, 'utf-8');
+      console.error(`Converted: ${file} -> ${outputPath}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`Error converting ${file}: ${message}`);
+    }
+  }
+}
+
+program.parse();

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,0 +1,49 @@
+import sharp from 'sharp';
+
+const DEFAULT_CHARSET = ' .:-=+*#%@';
+
+export interface ConvertOptions {
+  width?: number;
+  height?: number;
+  charset?: string;
+  invert?: boolean;
+}
+
+export async function convert(
+  inputPath: string,
+  options: ConvertOptions = {}
+): Promise<string> {
+  const {
+    width = 80,
+    height = 40,
+    charset = DEFAULT_CHARSET,
+    invert = true,
+  } = options;
+
+  if (width < 1 || height < 1) {
+    throw new Error('Width and height must be positive integers');
+  }
+  if (charset.length === 0) {
+    throw new Error('Charset must not be empty');
+  }
+
+  const pixels = await sharp(inputPath)
+    .resize(width, height, { fit: 'fill' })
+    .grayscale()
+    .raw()
+    .toBuffer();
+
+  const lines: string[] = [];
+  for (let y = 0; y < height; y++) {
+    let line = '';
+    for (let x = 0; x < width; x++) {
+      const brightness = pixels[y * width + x];
+      const value = invert ? 255 - brightness : brightness;
+      const charIndex = Math.floor((value / 256) * charset.length);
+      line += charset[Math.min(charIndex, charset.length - 1)];
+    }
+    lines.push(line);
+  }
+
+  return lines.join('\n');
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,120 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import sharp from 'sharp';
+
+const CLI_PATH = path.join(__dirname, '..', 'dist', 'cli.js');
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+const TEST_IMAGE = path.join(FIXTURES_DIR, 'cli_test.png');
+const TEST_IMAGE2 = path.join(FIXTURES_DIR, 'cli_test2.png');
+
+function run(args: string): string {
+  return execSync(`node ${CLI_PATH} ${args}`, { encoding: 'utf-8', timeout: 30000 });
+}
+
+function runWithError(args: string): { stdout: string; stderr: string; status: number } {
+  try {
+    const stdout = execSync(`node ${CLI_PATH} ${args}`, { encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'] });
+    return { stdout, stderr: '', status: 0 };
+  } catch (err: any) {
+    return { stdout: err.stdout || '', stderr: err.stderr || '', status: err.status || 1 };
+  }
+}
+
+beforeAll(async () => {
+  if (!fs.existsSync(FIXTURES_DIR)) {
+    fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  }
+  // Create test images
+  await sharp({
+    create: { width: 10, height: 10, channels: 3, background: { r: 128, g: 128, b: 128 } },
+  }).png().toFile(TEST_IMAGE);
+  await sharp({
+    create: { width: 10, height: 10, channels: 3, background: { r: 64, g: 64, b: 64 } },
+  }).png().toFile(TEST_IMAGE2);
+});
+
+afterAll(() => {
+  for (const f of [TEST_IMAGE, TEST_IMAGE2]) {
+    if (fs.existsSync(f)) fs.unlinkSync(f);
+  }
+  // Clean up any generated txt files
+  for (const f of fs.readdirSync(FIXTURES_DIR)) {
+    if (f.endsWith('.txt')) fs.unlinkSync(path.join(FIXTURES_DIR, f));
+  }
+  if (fs.existsSync(FIXTURES_DIR)) {
+    try { fs.rmdirSync(FIXTURES_DIR); } catch {}
+  }
+});
+
+describe('CLI', () => {
+  it('outputs ASCII art to stdout', () => {
+    const output = run(`${TEST_IMAGE} -w 20 -h 10`);
+    const lines = output.trim().split('\n');
+    expect(lines.length).toBe(10);
+    expect(lines[0].length).toBe(20);
+  });
+
+  it('--help shows usage', () => {
+    const output = run('--help');
+    expect(output).toContain('ascii-converter');
+    expect(output).toContain('--width');
+    expect(output).toContain('--output');
+  });
+
+  it('--output writes to a file', () => {
+    const outputFile = path.join(FIXTURES_DIR, 'output.txt');
+    run(`${TEST_IMAGE} -w 10 -h 5 -o ${outputFile}`);
+    expect(fs.existsSync(outputFile)).toBe(true);
+    const content = fs.readFileSync(outputFile, 'utf-8');
+    expect(content.split('\n').length).toBe(5);
+    fs.unlinkSync(outputFile);
+  });
+
+  it('--charset flag works', () => {
+    const output = run(`${TEST_IMAGE} -w 10 -h 5 -c "XO"`);
+    for (const ch of output.trim().replace(/\n/g, '')) {
+      expect('XO').toContain(ch);
+    }
+  });
+
+  it('--invert flag works', () => {
+    const normal = run(`${TEST_IMAGE} -w 10 -h 5 -i false`);
+    const inverted = run(`${TEST_IMAGE} -w 10 -h 5 -i true`);
+    expect(normal.trim()).not.toEqual(inverted.trim());
+  });
+
+  it('errors on missing file', () => {
+    const result = runWithError('/nonexistent/file.png');
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Error');
+  });
+
+  it('errors when no input specified', () => {
+    const result = runWithError('');
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Error');
+  });
+
+  it('batch mode converts multiple files', () => {
+    const txt1 = TEST_IMAGE.replace(/\.png$/, '.txt');
+    const txt2 = TEST_IMAGE2.replace(/\.png$/, '.txt');
+    // Clean up first
+    for (const f of [txt1, txt2]) {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    }
+
+    run(`-b "${FIXTURES_DIR}/*.png" -w 10 -h 5`);
+
+    expect(fs.existsSync(txt1)).toBe(true);
+    expect(fs.existsSync(txt2)).toBe(true);
+
+    const content1 = fs.readFileSync(txt1, 'utf-8');
+    expect(content1.split('\n').length).toBe(5);
+
+    // Clean up
+    for (const f of [txt1, txt2]) {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    }
+  });
+});

--- a/tests/converter.test.ts
+++ b/tests/converter.test.ts
@@ -1,0 +1,68 @@
+import { convert } from '../src/converter';
+import * as path from 'path';
+import sharp from 'sharp';
+import * as fs from 'fs';
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+const TEST_IMAGE = path.join(FIXTURES_DIR, 'test.png');
+
+beforeAll(async () => {
+  if (!fs.existsSync(FIXTURES_DIR)) {
+    fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  }
+  // Create a simple 10x10 white image
+  await sharp({
+    create: { width: 10, height: 10, channels: 3, background: { r: 255, g: 255, b: 255 } },
+  })
+    .png()
+    .toFile(TEST_IMAGE);
+});
+
+afterAll(() => {
+  if (fs.existsSync(TEST_IMAGE)) fs.unlinkSync(TEST_IMAGE);
+});
+
+describe('convert', () => {
+  it('returns a string with the correct number of lines', async () => {
+    const result = await convert(TEST_IMAGE, { width: 10, height: 5 });
+    const lines = result.split('\n');
+    expect(lines.length).toBe(5);
+    expect(lines[0].length).toBe(10);
+  });
+
+  it('uses default options', async () => {
+    const result = await convert(TEST_IMAGE);
+    const lines = result.split('\n');
+    expect(lines.length).toBe(40);
+    expect(lines[0].length).toBe(80);
+  });
+
+  it('respects custom charset', async () => {
+    const result = await convert(TEST_IMAGE, { width: 5, height: 5, charset: 'AB' });
+    // White image with invert=true should map to dark chars (first in charset)
+    for (const line of result.split('\n')) {
+      for (const ch of line) {
+        expect('AB').toContain(ch);
+      }
+    }
+  });
+
+  it('respects invert option', async () => {
+    const normal = await convert(TEST_IMAGE, { width: 5, height: 5, invert: false });
+    const inverted = await convert(TEST_IMAGE, { width: 5, height: 5, invert: true });
+    // White image: invert=false should use bright chars, invert=true should use dark chars
+    expect(normal).not.toEqual(inverted);
+  });
+
+  it('throws on missing file', async () => {
+    await expect(convert('/nonexistent/image.png')).rejects.toThrow();
+  });
+
+  it('throws on invalid dimensions', async () => {
+    await expect(convert(TEST_IMAGE, { width: 0 })).rejects.toThrow('Width and height must be positive');
+  });
+
+  it('throws on empty charset', async () => {
+    await expect(convert(TEST_IMAGE, { charset: '' })).rejects.toThrow('Charset must not be empty');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary

- Implements the core conversion library (`src/converter.ts`) using `sharp` for image loading/resizing and grayscale-to-ASCII character mapping
- Adds CLI tool (`src/cli.ts`) with `commander` for argument parsing, supporting `--width`, `--height`, `--charset`, `--invert`, `--output`, and `--batch` flags
- Includes project setup: `package.json` with `bin` entry, `tsconfig.json`, `jest.config.js`, `.gitignore`, and `README.md`
- Adds comprehensive tests for both the converter library and CLI (15 tests total)

## Test plan

- [x] `npx ascii-converter image.png` outputs ASCII art to stdout
- [x] `--output` flag writes to a file
- [x] `--width`, `--height`, `--invert`, `--charset` flags work
- [x] Batch mode converts multiple files
- [x] `--help` shows usage
- [x] Errors (missing file, no input) produce clear messages and non-zero exit
- [x] All 15 tests pass

Closes #2

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (frank-elk) 🤖